### PR TITLE
Remove /projects from example endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ if ($token instanceof \ActiveCollab\SDK\TokenInterface) {
 require_once '/path/to/vendor/autoload.php';
 
 // Provide name of your company, name of the app that you are developing, your email address and password. Last parameter is URL where your Active Collab is installed.
-$authenticator = new \ActiveCollab\SDK\Authenticator\SelfHosted('ACME Inc', 'My Awesome Application', 'you@acmeinc.com', 'hard to guess, easy to remember', 'https://my.company.com/projects');
+$authenticator = new \ActiveCollab\SDK\Authenticator\SelfHosted('ACME Inc', 'My Awesome Application', 'you@acmeinc.com', 'hard to guess, easy to remember', 'https://my.company.com/');
 
 // Issue a token.
 $token = $authenticator->issueToken();
@@ -78,7 +78,7 @@ $authenticator = new \ActiveCollab\SDK\Authenticator\Cloud('ACME Inc', 'My Aweso
 $authenticator->setSslVerifyPeer(false);
 
 // Self-hosted
-$authenticator = new \ActiveCollab\SDK\Authenticator\SelfHosted('ACME Inc', 'My Awesome Application', 'you@acmeinc.com', 'hard to guess, easy to remember', 'https://my.company.com/projects', false);
+$authenticator = new \ActiveCollab\SDK\Authenticator\SelfHosted('ACME Inc', 'My Awesome Application', 'you@acmeinc.com', 'hard to guess, easy to remember', 'https://my.company.com/', false);
 $authenticator->setSslVerifyPeer(false);
 
 // Client

--- a/example-self-hosted.php
+++ b/example-self-hosted.php
@@ -9,7 +9,7 @@
 require_once __DIR__ . '/vendor/autoload.php';
 
 // Construct a self-hosted authenticator. Last parameter is URL where your Active Collab
-$authenticator = new \ActiveCollab\SDK\Authenticator\SelfHosted('ACME Inc', 'My Awesome Application', 'you@acmeinc.com', 'hard to guess, easy to remember', 'https://my.company.com/projects');
+$authenticator = new \ActiveCollab\SDK\Authenticator\SelfHosted('ACME Inc', 'My Awesome Application', 'you@acmeinc.com', 'hard to guess, easy to remember', 'https://my.company.com/');
 
 // Issue a token
 $token = $authenticator->issueToken();


### PR DESCRIPTION
Hi there,

In your self hosted examples, you have the endpoint as "https://my.company.com/projects", but if you try to add any server based on that example (Eg. "https://zbr.blah.com/projects"). You always get:

`Invalid response from "https://zbr.blah.com/projects/api/v5/issue-token". JSON expected, got "text/html;charset=UTF-8", status code "200"`

After searching for that error, I've found this closed issue with the solution **from 2018**: https://github.com/activecollab/activecollab-feather-sdk/issues/18

That specifies that the endpoint URL **shouldn't have the /projects suffix**, but in your README and self hosted examples its still that way.

Here is a PR that changes the examples to make them work again.